### PR TITLE
Add Java Spring Boot TODO API with CRUD endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,21 @@ Run `ng github-pages:deploy` to deploy to GitHub Pages.
 ## Further help
 
 To get more help on the `angular-cli` use `ng help` or go check out the [Angular-CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+
+## API TODO Java Spring
+
+Un backend Spring Boot a été ajouté dans `todo-spring/` avec une API REST pour gérer les tâches.
+
+### Endpoints disponibles
+
+- `GET /api/tasks` : lister les tâches
+- `POST /api/tasks` : ajouter une tâche
+- `PUT /api/tasks/{id}` : modifier une tâche
+- `DELETE /api/tasks/{id}` : supprimer une tâche
+
+### Lancer le projet TODO
+
+```bash
+cd todo-spring
+mvn spring-boot:run
+```

--- a/todo-spring/pom.xml
+++ b/todo-spring/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.4</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>todo-spring</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>todo-spring</name>
+    <description>Simple TODO API with add/remove/update task endpoints</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/todo-spring/src/main/java/com/example/todo/TodoApplication.java
+++ b/todo-spring/src/main/java/com/example/todo/TodoApplication.java
@@ -1,0 +1,12 @@
+package com.example.todo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TodoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TodoApplication.class, args);
+    }
+}

--- a/todo-spring/src/main/java/com/example/todo/controller/TaskController.java
+++ b/todo-spring/src/main/java/com/example/todo/controller/TaskController.java
@@ -1,0 +1,53 @@
+package com.example.todo.controller;
+
+import com.example.todo.model.Task;
+import com.example.todo.service.TaskService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskController {
+
+    private final TaskService taskService;
+
+    public TaskController(TaskService taskService) {
+        this.taskService = taskService;
+    }
+
+    @GetMapping
+    public List<Task> getAllTasks() {
+        return taskService.findAll();
+    }
+
+    @PostMapping
+    public ResponseEntity<Task> addTask(@Valid @RequestBody Task task) {
+        Task createdTask = taskService.create(task);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdTask);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateTask(@PathVariable Long id, @Valid @RequestBody Task task) {
+        Task updatedTask = taskService.update(id, task);
+        if (updatedTask == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("message", "Task non trouvée"));
+        }
+        return ResponseEntity.ok(updatedTask);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteTask(@PathVariable Long id) {
+        boolean deleted = taskService.delete(id);
+        if (!deleted) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("message", "Task non trouvée"));
+        }
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/todo-spring/src/main/java/com/example/todo/model/Task.java
+++ b/todo-spring/src/main/java/com/example/todo/model/Task.java
@@ -1,0 +1,57 @@
+package com.example.todo.model;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class Task {
+
+    private Long id;
+
+    @NotBlank(message = "Le titre est obligatoire")
+    private String title;
+
+    private String description;
+
+    private boolean done;
+
+    public Task() {
+    }
+
+    public Task(Long id, String title, String description, boolean done) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.done = done;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public boolean isDone() {
+        return done;
+    }
+
+    public void setDone(boolean done) {
+        this.done = done;
+    }
+}

--- a/todo-spring/src/main/java/com/example/todo/service/TaskService.java
+++ b/todo-spring/src/main/java/com/example/todo/service/TaskService.java
@@ -1,0 +1,44 @@
+package com.example.todo.service;
+
+import com.example.todo.model.Task;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Service
+public class TaskService {
+
+    private final Map<Long, Task> tasks = new ConcurrentHashMap<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+
+    public List<Task> findAll() {
+        return new ArrayList<>(tasks.values());
+    }
+
+    public Task create(Task task) {
+        long id = idGenerator.getAndIncrement();
+        Task newTask = new Task(id, task.getTitle(), task.getDescription(), task.isDone());
+        tasks.put(id, newTask);
+        return newTask;
+    }
+
+    public Task update(Long id, Task task) {
+        Task existing = tasks.get(id);
+        if (existing == null) {
+            return null;
+        }
+
+        existing.setTitle(task.getTitle());
+        existing.setDescription(task.getDescription());
+        existing.setDone(task.isDone());
+        return existing;
+    }
+
+    public boolean delete(Long id) {
+        return tasks.remove(id) != null;
+    }
+}

--- a/todo-spring/src/main/resources/application.properties
+++ b/todo-spring/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=todo-spring


### PR DESCRIPTION
### Motivation

- Provide a simple backend for task management (add / list / update / delete) alongside the existing Angular frontend by adding a Spring Boot REST API under `todo-spring/`.

### Description

- Add a new Spring Boot project (`todo-spring/pom.xml`) with `spring-boot-starter-web`, validation and test dependencies and Java 17 configuration.
- Implement application entry point `TodoApplication` and set `spring.application.name` in `src/main/resources/application.properties`.
- Add `Task` model (`id`, `title`, `description`, `done`) with `@NotBlank` validation on the title in `model/Task.java`.
- Implement in-memory CRUD logic in `service/TaskService.java` using `ConcurrentHashMap` and `AtomicLong` and expose REST endpoints in `controller/TaskController.java` (`GET /api/tasks`, `POST /api/tasks`, `PUT /api/tasks/{id}`, `DELETE /api/tasks/{id}`).
- Update `README.md` with the new API section and run instructions (`cd todo-spring && mvn spring-boot:run`).

### Testing

- Ran `cd todo-spring && mvn test`, but dependency resolution failed due to HTTP 403 from Maven Central in this environment, so automated tests could not complete successfully.
- No unit tests were added to the new backend in this change, so runtime verification requires running `mvn spring-boot:run` in an environment with access to Maven Central.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4319def6c832986449999b735b3a4)